### PR TITLE
#48 Исправлена команда для переопределения глобального oscript для powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ set PATH=%OVM_OSCRIPTBIN%;%PATH%
 создается файл (либо добавляется в существующий) по адресу `%USERPROFILE%\Documents\WindowsPowerShell\profile.ps1` со следующим содержанием:
 
 ```powershell
-set PATH=$OVM_OSCRIPTBIN;$PATH
+$env:PATH=$env:OVM_OSCRIPTBIN+";"+$env:PATH
 ```
 
 ### sh (*nix)

--- a/src/core/Классы/АктиваторOneScript.os
+++ b/src/core/Классы/АктиваторOneScript.os
@@ -226,7 +226,7 @@
 		"profile.ps1"
 	);
 	
-	ТекстВычислениеPATH = "$env:PATH=$env:OVM_OSCRIPTBIN+";"+$env:PATH";
+	ТекстВычислениеPATH = "$env:PATH=$env:OVM_OSCRIPTBIN+"";""+$env:PATH";
 	ДобавитьТекстВНовыйИлиИмеющийсяФайл(ТекстВычислениеPATH, ПутьКФайлу);
 	
 КонецПроцедуры

--- a/src/core/Классы/АктиваторOneScript.os
+++ b/src/core/Классы/АктиваторOneScript.os
@@ -226,7 +226,7 @@
 		"profile.ps1"
 	);
 	
-	ТекстВычислениеPATH = "set PATH=$OVM_OSCRIPTBIN;$PATH";
+	ТекстВычислениеPATH = "$env:PATH=$env:OVM_OSCRIPTBIN+";"+$env:PATH";
 	ДобавитьТекстВНовыйИлиИмеющийсяФайл(ТекстВычислениеPATH, ПутьКФайлу);
 	
 КонецПроцедуры


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Документация**
  * Обновлена инструкция в README для корректного добавления переменной OVM_OSCRIPTBIN в PATH в PowerShell.

* **Исправления ошибок**
  * Исправлен синтаксис команды обновления PATH для PowerShell, чтобы переменная окружения добавлялась корректно.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->